### PR TITLE
Corrected ENV variables in run.sh - solves upload issue

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,9 @@ if [ -z ${APACHE_MAX_CHILDS_SPARE+x} ]; then APACHE_MAX_CHILDS_SPARE=5; fi
 if [ -z ${APACHE_SERVER_NAME+x} ]; then APACHE_SERVER_NAME=rainloop.loc; fi
 if [ -z ${APACHE_SERVER_ADMIN+x} ]; then APACHE_SERVER_ADMIN=webmaster@rainloop.loc; fi
 # PHP defaults
-if [ -z ${PHP_MAX_POST_SIZE+x} ]; then PHP_MAX_POST=20M; fi
+if [ -z ${PHP_MAX_POST_SIZE+x} ]; then PHP_MAX_POST_SIZE=20M; fi
 if [ -z ${PHP_MAX_UPLOAD_SIZE+x} ]; then PHP_MAX_UPLOAD_SIZE=8M; fi
-if [ -z ${PHP_MAX_UPLOADS+x} ]; then PHP_MAX_POST=20; fi
+if [ -z ${PHP_MAX_UPLOADS+x} ]; then PHP_MAX_UPLOADS=20; fi
 if [ -z ${PHP_MAX_EXECUTION_ZIME+x} ]; then PHP_MAX_EXECUTION_ZIME=30; fi
 # RAINLOOP defaults
 if [ -z ${RAINLOOP_ADMIN_LOGIN+x} ]; then RAINLOOP_ADMIN_LOGIN=admin; fi
@@ -27,9 +27,9 @@ sed "s/ServerAdmin .*/ServerAdmin $APACHE_SERVER_ADMIN/g" -i /etc/apache2/sites-
 
 echo "ServerName $APACHE_SERVER_NAME" > /etc/apache2/conf-enabled/servername.conf
 
-sed "s/post_max_size.*=.*/post_max_size = $PHP_MAX_POST/g" -i /etc/php/7.0/apache2/php.ini
+sed "s/post_max_size.*=.*/post_max_size = $PHP_MAX_POST_SIZE/g" -i /etc/php/7.0/apache2/php.ini
 sed "s/upload_max_filesize.*=.*/upload_max_filesize = $PHP_MAX_UPLOAD_SIZE/g" -i /etc/php/7.0/apache2/php.ini
-sed "s/max_file_uploads.*=.*/max_file_uploads = $PHP_MAX_POST/g" -i /etc/php/7.0/apache2/php.ini
+sed "s/max_file_uploads.*=.*/max_file_uploads = $PHP_MAX_UPLOADS/g" -i /etc/php/7.0/apache2/php.ini
 sed "s/max_execution_time.*=.*/max_execution_time = $PHP_MAX_EXECUTION_ZIME/g" -i /etc/php/7.0/apache2/php.ini
 
 if [ -f /var/www/html/data/_data_/_default_/configs/application.ini  ]; then


### PR DESCRIPTION
There were some copy/paste mistakes in run.sh that prevented Rainloop from accepting any attachments at all. The php.ini variable max_file_uploads wasn't being set.

Regards!